### PR TITLE
Support pathway summaries in ZIP downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Embedding Assistant is an AI-powered web application designed to support aca
 - **Smart General Document Inclusion**: Ensures that general-purpose materials (e.g. CV templates) are always shown, even during subject-specific searches.
 - **Tag Detection**: Automatically detects and stores useful tags like `general` and `main` for use in filtering and inclusion logic.
 - **Pathway Matching**: Recommends career development pathways from Target Connect using semantic similarity.
-- **Download as ZIP**: Users can select any number of documents and pathways to download as a single `.zip` file.
+- **Download as ZIP**: Users can select documents and pathways to download as a single `.zip`. When pathways are included, the archive also contains a `pathways.txt` summary file.
 - **Higher Education Level Dropdown**: Academic level input now reflects HE levels 4, 5, 6, and 7.
 - **Loading Spinner**: Shows a visual spinner when the assistant is processing.
 - **Traditional Layout**: Simplified, accessible front-end designed for ease of use and clarity.
@@ -63,7 +63,7 @@ This ensures that broadly useful files are always returned alongside subject-spe
 Users can:
 - Tick checkboxes next to documents
 - Optionally include matched career pathways
-- Download everything as one `.zip` file via the "Download Selected" button
+- Download everything as one `.zip` via the "Download Selected" button. If pathways are included, a `pathways.txt` file listing them is added to the archive.
 
 ---
 

--- a/tests/test_download_zip.py
+++ b/tests/test_download_zip.py
@@ -1,0 +1,58 @@
+import importlib.util
+from pathlib import Path
+import io
+import zipfile
+
+spec = importlib.util.spec_from_file_location("main", Path(__file__).resolve().parents[1] / "main.py")
+main = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(main)
+
+class DummyContainer:
+    def get_blob_client(self, name):
+        class BlobClient:
+            def download_blob(self):
+                class Blob:
+                    def readall(self):
+                        return b"content-" + name.encode()
+                return Blob()
+        return BlobClient()
+
+class DummyService:
+    @classmethod
+    def from_connection_string(cls, *a, **k):
+        return cls()
+    def get_container_client(self, *a, **k):
+        return DummyContainer()
+
+
+def test_zip_includes_pathways(monkeypatch):
+    monkeypatch.setattr(main, "BlobServiceClient", DummyService)
+    monkeypatch.setattr(main, "MAX_DOWNLOAD_WORKERS", 1)
+
+    data = {
+        "files": ["doc1.txt"],
+        "pathways": [
+            {"title": "T", "description": "D", "url": "U"}
+        ]
+    }
+
+    class DummyReq:
+        @staticmethod
+        def get_json():
+            return data
+    monkeypatch.setattr(main, "request", DummyReq)
+
+    captured = {}
+    def fake_send_file(buf, as_attachment=False, download_name=None):
+        captured["bytes"] = buf.getvalue()
+        captured["name"] = download_name
+        return "sent"
+    monkeypatch.setattr(main, "send_file", fake_send_file)
+
+    assert main.download_zip() == "sent"
+    z = zipfile.ZipFile(io.BytesIO(captured["bytes"]))
+    assert set(z.namelist()) == {"doc1.txt", "pathways.txt"}
+    text = z.read("pathways.txt").decode()
+    assert "Title: T" in text
+    assert "Description: D" in text
+    assert "URL: U" in text

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,7 +17,11 @@ def test_get_links_with_summaries_includes_general(monkeypatch):
     all_docs = query_docs + [DummyDoc({'source': 'general.txt', 'summary': 'gen sum', 'tags': ['general']})]
 
     class DummyIndex:
-        def similarity_search(self, query, k=15):
+        def similarity_search_with_score(self, query, k=15):
+            docs = query_docs if query else all_docs
+            return [(d, 0.1) for d in docs]
+
+        def similarity_search(self, query, k=50):
             return all_docs if query == '' else query_docs
 
     monkeypatch.setattr(main, 'VECTOR_INDEX', DummyIndex())


### PR DESCRIPTION
## Summary
- include optional `pathways.txt` file when creating ZIP downloads
- document `pathways.txt` behaviour in README
- add unit test for new `/download_zip` behaviour
- update existing test helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0e6d2e94832ca8c04d0c2ee36aed