### PR TITLE
Filter general docs by metadata

### DIFF
--- a/main.py
+++ b/main.py
@@ -123,11 +123,11 @@ def get_links_with_summaries(query, top_k: int = 6):
         # Request scores from FAISS for query-specific results
         ranked_docs = VECTOR_INDEX.similarity_search_with_score(query, k=15)
 
-        # Fetch general docs without filtering by query similarity
-        general_pool = VECTOR_INDEX.similarity_search("", k=50)
+        # Fetch general docs by filtering metadata tags
+        doc_dict = getattr(VECTOR_INDEX.docstore, "_dict", {})
         general_docs = [
             (doc, float("inf"))
-            for doc in general_pool
+            for doc in doc_dict.values()
             if "general" in doc.metadata.get("tags", [])
             or "main" in doc.metadata.get("tags", [])
         ]

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -90,15 +90,17 @@ class DummyIndex:
         self._query_docs = [
             (DummyDoc(n, f'sum-{n}', t), s) for n, s, t in query_docs
         ]
-        self._general_docs = [DummyDoc(n, f'sum-{n}', ['general']) for n in general_docs]
+        self.docstore = type('ds', (), {'_dict': {}})()
+        i = 0
+        for doc, _ in self._query_docs:
+            self.docstore._dict[f'q{i}'] = doc
+            i += 1
+        for name in general_docs:
+            self.docstore._dict[f'g{i}'] = DummyDoc(name, f'sum-{name}', ['general'])
+            i += 1
 
     def similarity_search_with_score(self, query, k=15):
         return self._query_docs[:k]
-
-    def similarity_search(self, query, k=50):
-        if query == "":
-            return self._general_docs[:k]
-        return []
 
 
 def test_general_docs_added_when_missing():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,16 +13,15 @@ class DummyDoc:
 
 
 def test_get_links_with_summaries_includes_general(monkeypatch):
-    query_docs = [DummyDoc({'source': 'doc1.pdf', 'summary': 'doc1 sum', 'tags': []})]
-    all_docs = query_docs + [DummyDoc({'source': 'general.txt', 'summary': 'gen sum', 'tags': ['general']})]
+    query_doc = DummyDoc({'source': 'doc1.pdf', 'summary': 'doc1 sum', 'tags': []})
+    general_doc = DummyDoc({'source': 'general.txt', 'summary': 'gen sum', 'tags': ['general']})
 
     class DummyIndex:
-        def similarity_search_with_score(self, query, k=15):
-            docs = query_docs if query else all_docs
-            return [(d, 0.1) for d in docs]
+        def __init__(self):
+            self.docstore = type('ds', (), {'_dict': {'q': query_doc, 'g': general_doc}})()
 
-        def similarity_search(self, query, k=50):
-            return all_docs if query == '' else query_docs
+        def similarity_search_with_score(self, query, k=15):
+            return [(query_doc, 0.1)]
 
     monkeypatch.setattr(main, 'VECTOR_INDEX', DummyIndex())
     monkeypatch.setattr(main, 'AZURE_BLOB_BASE_URL', 'https://files/')


### PR DESCRIPTION
## Summary
- adjust `get_links_with_summaries` to pull general documents from the FAISS docstore using tag metadata instead of a blank similarity search
- update unit tests for new docstore behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f333d19f8832cbe53c8874fd27584